### PR TITLE
Update to lua 4.0.0, add log levels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elrsbuddy",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "elrsbuddy",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "GPL-3.0",
       "dependencies": {
         "wasmoon": "^1.16.0"

--- a/src/index.html
+++ b/src/index.html
@@ -30,6 +30,12 @@ a {
 				</select>
 				<button id="connect" disabled="disabled">connect</button>
 				<button id="start" disabled="disabled">(re)start</button>
+				<select id="log-level" style="width: auto;">
+					<option value="0">DEBUG</option>
+					<option value="1" selected="selected">INFO</option>
+					<option value="2">WARN</option>
+					<option value="3">ERROR</option>
+				</select>
 			</div>
 			<div id="crsfstatus" style="text-align: center;"></div>
 			<canvas id="lcd" width="480" height="272" style="display:block; margin-left:auto; margin-right:auto;"></canvas>
@@ -39,7 +45,16 @@ a {
 				<div><img src="logotype.svg" style="padding:0.3em;"></div>
 				<div style="margin:auto;"><div>ELRS Buddy</div><div style="font-size:0.5em; font-weight:normal; text-align:right;">v1.0.4</div></div>
 			</div>
-			<div style="text-align: center;">
+			<div id="lua-info" style="color: white; text-align: center; margin-top: 1em;">
+				<div style="font-size: 0.9em; opacity: 0.8;">Current: <span id="lua-filename">elrsV3.lua</span></div>
+				<div id="lua-version" style="font-weight: bold; margin-top: 0.2em;">-- (no connection)</div>
+			</div>
+			<div style="text-align: center; margin-top: 1em; display: flex; flex-direction: column; gap: 0.5em; align-items: center;">
+				<button id="upload-btn" style="width: auto; padding: 0.5em 1em; cursor: pointer; border-radius: 4px; border: 1px solid white; background: rgba(255,255,255,0.1); color: white;">Upload Lua</button>
+				<input type="file" id="lua-upload" style="display: none;" accept=".lua">
+				<a id="download-link" href="elrsV3.lua" download="elrsV3.lua" style="font-size: 0.8em; color: white; opacity: 0.7; text-decoration: underline;">Download Current Lua</a>
+			</div>
+			<div style="text-align: center; margin-top: 2em;">
 				<a target="_blank" href="https://youtube.com/playlist?list=PL5blJzbVpLjFwGb_-_IBfnscjPwTEA98u">Introduction / Howto</a>
 			</div>
 		</div>
@@ -158,8 +173,8 @@ a {
 		return table.pack(f(...))
 	end
 	
-	function loadelrs ()
-		ELRS_LOAD = loadfile('elrsV3.lua')
+	function loadelrs (filename)
+		ELRS_LOAD = loadfile(filename or 'elrsV3.lua')
 		return ELRS_LOAD
 	end
 	
@@ -222,6 +237,7 @@ lcd = {
 		if (lcd.debug) console.log(`textAlign ${lcd.ctx.textAlign} font ${lcd.ctx.font}`);
 	},
 	'clear': function (color) {
+		llog('LCD:CLEAR', 0);
 		if (lcd.debug) console.log('clear');
 		lcd.ctx.reset();
 		lcd.lastpos = 0;
@@ -247,18 +263,21 @@ lcd = {
 		lcd.lastpos = x + w;
 	},
 	'drawRectangle': function (x, y, w, h, flags, t) {
+		llog(`LCD:DRAWRECT ${x},${y},${w},${h}`, 0);
 		lcd.strokeStyle(flags);
 		lcd.ctx.strokeRect(x, y, w, h);
 		lcd.lastpos = x + w;
 		if (lcd.debug) console.log(`drawRectangle ${flags}`);
 	},
 	'drawFilledRectangle': function (x, y, w, h, flags) {
+		llog(`LCD:DRAWFRECT ${x},${y},${w},${h}`, 0);
 		lcd.fillStyle(flags);
 		lcd.ctx.fillRect(x, y, w, h);
 		lcd.lastpos = x + w;
 		if (lcd.debug) console.log(`drawFilledRectangle ${flags}`);
 	},
 	'drawText': function (x, y, text, flags, inversColor) {
+		llog(`LCD:DRAWTEXT ${text}`, 0);
 		if (lcd.debug) console.log(`drawText ${flags} ${text}`);
 		lcd.textConfig(flags);
 		const tmetrics = lcd.ctx.measureText(text);
@@ -294,7 +313,8 @@ lcd = {
 		lcd.textConfig(flags);
 		const tmetrics = lcd.ctx.measureText(text);
 		const boundw = Math.round(tmetrics.actualBoundingBoxLeft + tmetrics.actualBoundingBoxRight);
-		return boundw;
+		const boundh = Math.round(tmetrics.actualBoundingBoxAscent + tmetrics.actualBoundingBoxDescent);
+		return [boundw, boundh || 22];
 	},
 	'getLastPos': function () {
 		return lcd.lastpos;
@@ -325,8 +345,10 @@ function try_tag (tag) {
 	window.lua.doStringSync(tag.innerHTML);
 };
 
-function llog (msg) {
-	console.log(msg);
+function llog (msg, level = 1) {
+	const currentLevel = parseInt(document.getElementById('log-level')?.value || 1);
+	if (level < currentLevel) return;
+	console.log(`[${level}] ${msg}`);
 }
 
 function portstr (info) {
@@ -346,6 +368,11 @@ function portstr (info) {
 }
 
 function loadpairedports (verbose=true) {
+	if (navigator.serial === undefined) {
+		llog('Browser does not support Web Serial API (e.g. Safari). Please use a Chrome-based browser.', 3);
+		pairbutton.disabled = true;
+		return;
+	}
 	navigator.serial.getPorts().then((ports) => {
 		let info;
 		let npairedport = null;
@@ -357,7 +384,7 @@ function loadpairedports (verbose=true) {
 				port: port,
 				info: str
 			};
-			if (verbose) llog(`device ${str} found`);
+			if (verbose) llog(`device ${str} found`, 1);
 			break;
 		}
 		pairedport = npairedport;
@@ -372,6 +399,8 @@ function loadpairedports (verbose=true) {
 			connbutton.disabled = true;
 			connbutton.innerHTML = 'connect';
 		}
+	}).catch((e) => {
+		llog(`Error listing ports: ${e.message}`, 3);
 	});
 }
 
@@ -387,12 +416,18 @@ function edgetx_popupConfirmation (title, message, event) {
 }
 
 function elrsrun (key = 0) {
+	if (elrs == null || typeof elrs.run !== 'function') return;
 	popup_status.visible = false;
-	if (elrs.run(key) != 0) {
-		llog('ELRS Lua exited!');
-		crossfireFlush();
-		elrsrefresh(true);
-		elrs = null;
+	try {
+		if (elrs.run(key) != 0) {
+			llog('ELRS Lua exited!', 1);
+			crossfireFlush();
+			elrsrefresh(true);
+			elrs = null;
+			return;
+		}
+	} catch (e) {
+		showLuaError(e.message);
 		return;
 	}
 	ret = multiret('crossfireTelemetryPush');
@@ -400,8 +435,38 @@ function elrsrun (key = 0) {
 		comworker.postMessage(['crsfsend', ret[1], ret[2]]);
 	}
 	if (popup_status.visible) {
-		llog(`popup ${popup_status.title}: ${popup_status.message}`);
+		llog(`popup ${popup_status.title}: ${popup_status.message}`, 1);
 	}
+}
+
+function showLuaError(msg) {
+	llog('LUA ERROR: ' + msg, 3);
+	elrsrefresh(true);
+	elrs = null;
+	
+	// Draw error on LCD
+	lcd.clear();
+	lcd.ctx.fillStyle = '#ff0000';
+	lcd.ctx.font = 'bold 24px monospace';
+	lcd.ctx.fillText('LUA ERROR', 10, 40);
+	lcd.ctx.fillStyle = '#ffffff';
+	lcd.ctx.font = '14px monospace';
+	
+	// Simple text wrapping for the error message
+	const words = msg.split(' ');
+	let line = '';
+	let y = 70;
+	for (let n = 0; n < words.length; n++) {
+		let testLine = line + words[n] + ' ';
+		if (testLine.length > 50) {
+			lcd.ctx.fillText(line, 10, y);
+			line = words[n] + ' ';
+			y += 20;
+		} else {
+			line = testLine;
+		}
+	}
+	lcd.ctx.fillText(line, 10, y);
 }
 
 function elrsrefresh (clear=false) {
@@ -420,6 +485,11 @@ async function boot () {
 	const lua = await wasmoon.factory.createEngine();
 	window.lua = lua;
 	lua.global.set('getTime', get_uptime);
+	
+	// Map Lua print to our llog with level support. 
+	// Lua draw calls often use print, so they default to DEBUG (0).
+	lua.global.set('print', (msg) => llog(msg, 0));
+
 	const selector = 'script[type^="application/lua"], script[type^="text/lua"]';
 	Array.prototype.forEach.call(document.querySelectorAll(selector), try_tag);
 	if (elrs_load === true) {
@@ -433,9 +503,15 @@ async function boot () {
 	multiret = lua.global.get('multiret');
 	const logelem = document.getElementById("log");
 	if (logelem) {
-		llog = function (msg) {
+		llog = function (msg, level = 1) {
+			const currentLevel = parseInt(document.getElementById('log-level').value);
+			if (level < currentLevel) return;
 			const tm = get_uptime();
 			logelem.append(`${tm} ${msg}\n`);
+			// Auto scroll to bottom
+			if (logelem.parentElement) {
+				logelem.parentElement.scrollTop = logelem.parentElement.scrollHeight;
+			}
 		}
 	}
 	loadpairedports();
@@ -450,7 +526,35 @@ async function boot () {
 	lcd.BLACK = lua.global.get('BLACK');
 	lcd.WHITE = lua.global.get('WHITE');
 	lcd.CUSTOM_COLOR = lua.global.get('CUSTOM_COLOR');
-	lua.global.set('lcd', lcd);
+	
+	// Map JS functions to the Lua 'lcd' table individually.
+	// This preserves the Lua table structure and allows native Lua wrappers.
+	lua.global.set('jsLcd', lcd);
+	await window.lua.doString(`
+		lcd = lcd or {}
+		lcd.clear = function(...) return jsLcd.clear(...) end
+		lcd.drawLine = function(...) return jsLcd.drawLine(...) end
+		lcd.drawGauge = function(...) return jsLcd.drawGauge(...) end
+		lcd.drawRectangle = function(...) return jsLcd.drawRectangle(...) end
+		lcd.drawFilledRectangle = function(...) return jsLcd.drawFilledRectangle(...) end
+		lcd.drawText = function(...) return jsLcd.drawText(...) end
+		lcd.setColor = function(...) return jsLcd.setColor(...) end
+		lcd.RGB = function(...) return jsLcd.RGB(...) end
+		lcd.getLastPos = function(...) return jsLcd.getLastPos(...) end
+		
+		-- Native Lua wrapper for sizeText to correctly return multiple values.
+		-- Wasmoon proxies JS arrays as objects where indices start at 0.
+		lcd.sizeText = function(...)
+			local res = jsLcd.sizeText(...)
+			if res then
+				local w = tonumber(res[0]) or tonumber(res[1]) or 0
+				local h = tonumber(res[1]) or tonumber(res[2]) or 22
+				return w, h
+			end
+			return 0, 22
+		end
+	`);
+
 	lua.global.set('popupConfirmation', edgetx_popupConfirmation);
 	let key = lua.global.get('EVT_VIRTUAL_ENTER');
 	keymap[13] = key; // Enter
@@ -483,6 +587,79 @@ connbutton = document.getElementById('connect');
 pairbutton = document.getElementById('pair');
 startbutton = document.getElementById('start');
 statusspan = document.getElementById('crsfstatus');
+uploadbtn = document.getElementById('upload-btn');
+fileupload = document.getElementById('lua-upload');
+filename_display = document.getElementById('lua-filename');
+download_link = document.getElementById('download-link');
+
+uploadbtn.addEventListener('click', () => fileupload.click());
+fileupload.addEventListener('change', async (ev) => {
+	const file = ev.target.files[0];
+	if (!file) return;
+	
+	llog(`Loading ${file.name}...`, 1);
+	const text = await file.text();
+	
+	// Show last 5 lines to verify content
+	const lines = text.trim().split('\n');
+	const lastLines = lines.slice(-5);
+	llog('--- Last 5 lines ---', 1);
+	lastLines.forEach(l => llog('> ' + l, 1));
+	llog('-------------------', 1);
+
+	const uint8 = new TextEncoder().encode(text);
+	
+	// Use a unique filename in the virtual FS to force a fresh load
+	const vFilename = `upload_${Date.now()}.lua`;
+	await wasmoon.factory.mountFile(vFilename, uint8);
+	
+	filename_display.innerText = file.name;
+	
+	const blob = new Blob([text], { type: 'text/x-lua' });
+	const url = URL.createObjectURL(blob);
+	download_link.href = url;
+	download_link.download = file.name;
+
+	// Reset state and clear canvas
+	if (elrs != null) {
+		elrsrefresh(true);
+		elrs = null;
+	}
+	crossfireFlush();
+	lcd.clear(); // Clear the LCD so we don't see old frames
+
+	try {
+		// Pass the unique filename to the loader
+		const elrs_loader_factory = await window.lua.doString(`return loadelrs("${vFilename}")`);
+		if (typeof elrs_loader_factory !== 'function') {
+			throw new Error('Script did not return a valid loader function');
+		}
+		
+		elrs = elrs_loader_factory();
+		if (!elrs) {
+			throw new Error('Script returned nil');
+		}
+		
+		// Detailed check of required functions
+		const hasInit = typeof elrs.init === 'function';
+		const hasRun = typeof elrs.run === 'function';
+		
+		if (!hasInit || !hasRun) {
+			let missing = [];
+			if (!hasInit) missing.push('init()');
+			if (!hasRun) missing.push('run()');
+			throw new Error(`Script is missing ${missing.join(' and ')} function(s)`);
+		}
+
+		llog(`Initializing ${file.name}...`, 1);
+		elrs.init();
+		elrsrefresh();
+		llog(`${file.name} started successfully`, 1);
+	} catch (e) {
+		showLuaError(e.message);
+		console.error('Lua Load Error:', e);
+	}
+});
 popup_status = {
 	'title': null,
 	'message': null,
@@ -529,10 +706,10 @@ const status = {
 		} else {
 			this.bootiters++;
 			if (this.bootiters > 3) {
-				llog('Unresponsive CRSF, disconnecting...');
+				llog('Unresponsive CRSF, disconnecting...', 2);
 				comworker.postMessage(["stop"]);
 			} else if (this.bootiters > 1) {
-				llog('No CRSF response in >5 seconds');
+				llog('No CRSF response in >5 seconds', 2);
 			}
 		}
 		return this.update_main();
@@ -556,16 +733,18 @@ status.reset();
 
 const workermsg = {
 	'started': function (data) {
-		llog("serial worker started");
+		llog("serial worker started", 1);
 		connbutton.innerHTML = 'disconnect';
 		baudselect.disabled = true;
+		document.getElementById('lua-version').innerText = 'connecting...';
 		status.start();
 	},
 	'stopped': function (data) {
-		llog("serial worker stopped");
+		llog("serial worker stopped", 1);
 		connbutton.innerHTML = 'connect';
 		startbutton.disabled = true;
 		baudselect.disabled = false;
+		document.getElementById('lua-version').innerText = '-- (no connection)';
 		crossfireFlush();
 		status.reset();
 		elrsrefresh(true);
@@ -575,7 +754,7 @@ const workermsg = {
 		comworker.postMessage(data);
 	},
 	'log': function (data) {
-		llog(data[1]);
+		llog(data[1], data[2]);
 	},
 	'sync': function (data) {
 		var quickupd = false;
@@ -587,7 +766,7 @@ const workermsg = {
 		if (quickupd) status.update();
 	},
 	'start': function (data) {
-		llog('starting ELRS');
+		llog('starting ELRS', 1);
 		elrs = elrs_load();
 		elrs.init();
 		elrsrefresh();
@@ -597,6 +776,11 @@ const workermsg = {
 		var cmd = data[1];
 		var d = data[2];
 		crossfirePop(cmd, d);
+	},
+	'devinfo': function (data) {
+		const name = data[1];
+		const ver = `${data[2]}.${data[3]}.${data[4]}`;
+		document.getElementById('lua-version').innerText = `${name} (v${ver})`;
 	}
 };
 
@@ -627,33 +811,44 @@ document.querySelector('script[src="elrsV3.lua"]').addEventListener(
 	}
 );
 
-navigator.serial.addEventListener("connect", (e) => {
+navigator.serial?.addEventListener("connect", (e) => {
 	const info = e.target.getInfo();
 	const str = portstr(info);
-	llog(`paired device ${str} attached`);
+	llog(`paired device ${str} attached`, 1);
 	loadpairedports(false);
 });
-navigator.serial.addEventListener("disconnect", (e) => {
+navigator.serial?.addEventListener("disconnect", (e) => {
 	const info = e.target.getInfo();
 	const str = portstr(info);
-	llog(`paired device ${str} detached`);
+	llog(`paired device ${str} detached`, 1);
 	loadpairedports(false);
 });
 
 pairbutton.addEventListener("click", () => {
+	if (navigator.serial === undefined) {
+		llog('Browser does not support Web Serial API. Pairing unavailable.', 3);
+		return;
+	}
 	if (pairedport != null) {
 		pairedport.port.forget().then(() => {
-			llog(`device ${pairedport.info} unpaired`);
+			llog(`device ${pairedport.info} unpaired`, 1);
 			loadpairedports();
+		}).catch((e) => {
+			llog(`Error unpairing: ${e.message}`, 3);
 		});
 	} else {
+		llog('Requesting device pair...', 1);
 		navigator.serial.requestPort().then((port) => {
 			const info = port.getInfo();
 			const str = portstr(info);
-			llog(`device ${str} paired`);
+			llog(`device ${str} paired`, 1);
 			loadpairedports(false);
 		}).catch((e) => {
-			if (e.name == 'NotFoundError') return;
+			if (e.name == 'NotFoundError') {
+				llog('Pairing cancelled by user', 1);
+				return;
+			}
+			llog(`Error pairing: ${e.message}`, 3);
 			throw(e);
 		});
 	}
@@ -670,7 +865,7 @@ connbutton.addEventListener("click", () => {
 });
 
 startbutton.addEventListener('click', () => {
-	llog('(re)starting ELRS');
+	llog('(re)starting ELRS', 1);
 	if (elrs != null) {
 		crossfireFlush();
 		elrsrefresh(true);

--- a/src/worker.js
+++ b/src/worker.js
@@ -108,8 +108,23 @@ function decode_extended (buf) {
 }
 
 function decode_unknown (buf, type) {
-	log(`unknown ${type}: ` + hexprintable(new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)));
+	log(`unknown ${type}: ` + hexprintable(new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)), 0);
 	return DECODED_UNKNOWN;
+}
+
+function decode_link_statistics (buf) {
+	const up_rssi1 = buf.getUint8(0);
+	const up_rssi2 = buf.getUint8(1);
+	const up_lq = buf.getUint8(2);
+	const up_snr = buf.getInt8(3);
+	const active_ant = buf.getUint8(4);
+	const rf_mode = buf.getUint8(5);
+	const up_tx_pwr = buf.getUint8(6);
+	const dn_rssi = buf.getUint8(7);
+	const dn_lq = buf.getUint8(8);
+	const dn_snr = buf.getInt8(9);
+	log(`LINK_STAT: up_lq=${up_lq} up_snr=${up_snr} rf_mode=${rf_mode} dn_lq=${dn_lq} dn_snr=${dn_snr}`, 0);
+	return DECODED_FORWARD;
 }
 
 function decode_elrs_status (buf) {
@@ -122,14 +137,14 @@ function decode_elrs_status (buf) {
 		if (buf.getUint8(n) == 0) break;
 	}
 	const msg = bytes2str(new Uint8Array(buf.buffer, buf.byteOffset+6, buf.byteLength-6));
-	log(`${src}->${dst} ELRS_STATUS: nbad=${nbad} ngood=${ngood} flags=${flags} msg=${msg}`);
+	log(`${src}->${dst} ELRS_STATUS: nbad=${nbad} ngood=${ngood} flags=${flags} msg=${msg}`, 1);
 	return DECODED_FORWARD;
 }
 
 function decode_parameter_write (buf) {
 	const [ dst, src ] = decode_extended(buf);
 	const idx = buf.getUint8(2);
-	log(`${src}->${dst} PARAMETER_WRITE: ${idx}`);
+	log(`${src}->${dst} PARAMETER_WRITE: ${idx}`, 1);
 	return DECODED_FORWARD;
 }
 
@@ -138,7 +153,7 @@ function decode_parameter_settings_entry (buf) {
 	var idx = buf.getUint8(2);
 	var left = buf.getUint8(3);
 	var end = new Uint8Array(buf.buffer, buf.byteOffset+4, buf.byteLength-4);
-	log(`${src}->${dst} SETTINGS_ENTRY: ${idx} ${left}: ${hexprintable(end)}`);
+	log(`${src}->${dst} SETTINGS_ENTRY: ${idx} ${left}: ${hexprintable(end)}`, 1);
 	return DECODED_FORWARD;
 }
 
@@ -163,7 +178,8 @@ function decode_device_info (buf) {
 		rev = buf.getUint8(n++);
 		npar = buf.getUint8(n++);
 		pver = buf.getUint8(n++);
-		log(`${src}->${dst} DEVICE_INFO: ${name} (${serial}) hwver=${hwver} swver=${maj}.${min}.${rev} npar=${npar} pver=${pver}`);
+		log(`${src}->${dst} DEVICE_INFO: ${name} (${serial}) hwver=${hwver} swver=${maj}.${min}.${rev} npar=${npar} pver=${pver}`, 1);
+		self.postMessage(['devinfo', name, maj, min, rev]);
 	}
 	return DECODED_FORWARD;
 }
@@ -175,14 +191,14 @@ function decode_radio_id (buf) {
 		shift = buf.getInt32(7);
 		self.postMessage(["sync", (10000000/interval).toFixed(1), shift]);
 		if (interval != write_interval) {
-			log(`worker adjusting loopinterval ${write_interval}=>${interval}`);
+			log(`worker adjusting loopinterval ${write_interval}=>${interval}`, 1);
 			write_interval = interval;
 		}
 		write_shift = shift;
 		// for debugging timing issues
 		//console.log(`sync ${shift}`);
 	} else {
-		log('SYNC: unknown subtype!');
+		log('SYNC: unknown subtype!', 1);
 	}
 	return DECODED_FINISHED;
 }
@@ -205,7 +221,7 @@ const DECODE = Array(
 	decode_unknown, // CRSF_FRAMETYPE_HEARTBEAT
 	decode_unknown, decode_unknown, decode_unknown, decode_unknown,
 	decode_unknown, decode_unknown, decode_unknown, decode_unknown,
-	decode_unknown, // CRSF_FRAMETYPE_LINK_STATISTICS
+	decode_link_statistics, // CRSF_FRAMETYPE_LINK_STATISTICS
 	decode_unknown,
 	decode_unknown, // CRSF_FRAMETYPE_RC_CHANNELS_PACKED
 	decode_unknown, // CRSF_FRAMETYPE_SUBSET_RC_CHANNELS_PACKED
@@ -286,8 +302,8 @@ const DECODE = Array(
 	decode_unknown, decode_unknown, decode_unknown
 );
 	
-function log (msg) {
-	self.postMessage(["log", msg]);
+function log (msg, level = 1) {
+	self.postMessage(["log", msg, level]);
 }
 
 function hex (buf) {
@@ -391,7 +407,7 @@ function read_run (rbuf = new ArrayBuffer(255), offset = 0) {
 				break;
 			} while (tblen > 1);
 			if (tboffset > 0) {
-				log("noise: " + hexprintable(new Uint8Array(value.buffer, 0, tboffset)));
+				log("noise: " + hexprintable(new Uint8Array(value.buffer, 0, tboffset)), 0);
 				offset = buf_shift(value.buffer, tboffset, offset);
 			}
 			if (len == 0) {
@@ -441,7 +457,7 @@ function write_burn (lastwrite) {
 
 function write_run () {
 	if (writes_burn+writes_st > 300) {
-		log(`writes_burn=${writes_burn} writes_st=${writes_st}`);
+		log(`writes_burn=${writes_burn} writes_st=${writes_st}`, 0);
 		writes_burn = writes_st = 0;
 	}
 	writer.write(wbuf.b.subarray(0, wbuf.offset)).then(() => {
@@ -476,13 +492,13 @@ uimessage = {
 		DECODE[CRSF_FRAMETYPE_RADIO_ID] = decode_radio_id_start;
 		navigator.serial.getPorts().then((ports) => {
 			if (ports.length < 1) {
-				log('error connecting: no ports found');
+				log('error connecting: no ports found', 1);
 				return;
 			}
 			port = ports[0];
 			baud = Number(data[1]);
 			port.open({baudRate: baud}).then(() => {
-				log(`opened port at ${baud} bps`);
+				log(`opened port at ${baud} bps`, 1);
 				writer = port.writable.getWriter();
 				write = write_run;
 				write();
@@ -492,10 +508,10 @@ uimessage = {
 				self.postMessage(["started"]);
 				self.postMessage(["sync", (10000000/write_interval).toFixed(1)]);
 			}).catch((e) => {
-				log(`error connecting to port: ${e.name} ${e.message}`);
+				log(`error connecting to port: ${e.name} ${e.message}`, 1);
 			});
 		}).catch((e) => {
-			log(`worker error: onmessage ${e.name} ${e.message}`);
+			log(`worker error: onmessage ${e.name} ${e.message}`, 1);
 		});
 	},
 	'stop': function (data) {
@@ -519,7 +535,7 @@ uimessage = {
 		wbuf.b.set(data[2], wbuf.offset);
 		wbuf.offset += data[2].length;
 		wbuf.b.set(crc8(wbuf.b.subarray(cst, wbuf.offset)), wbuf.offset++);
-		log(`worker sending: ${hexprintable(wbuf.b.subarray(start,wbuf.offset))}`);
+		log(`worker sending: ${hexprintable(wbuf.b.subarray(start,wbuf.offset))}`, 0);
 	},
 	'crctable': function (data) {
 		console.log(`${CRC8TABLE}`);


### PR DESCRIPTION
While using your excellent tool for modernizing my Grouper MC-24, I’ve been struggling to comprehend how everything works. Here’s the result of my lack of knowledge. I hope it helps the next person!

  Summary of changes in this commit:
   - Lua Compatibility: Fixed ELRS V4 script crashes by properly handling lcd.sizeText multiple return values.
   - Link Statistics: Added a decoder for CRSF Link Statistics (frame type 20) to parse telemetry data.
   - Log Levels: Added a UI pulldown to toggle between DEBUG, INFO, and ERROR levels, filtering out high-frequency
     messages like draw calls and telemetry.
   - Robust Uploads: Implemented cache-busting for Lua script uploads using unique filenames and added visual lua script error
     reporting on the LCD canvas.
   - UI Enhancements: Added firmware version display and automatic scrolling for the log.
